### PR TITLE
Take cargo features into account through USE flags.

### DIFF
--- a/src/ebuild.template
+++ b/src/ebuild.template
@@ -17,7 +17,16 @@ RESTRICT="mirror"
 LICENSE="{license}" # Update to proper Gentoo format
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE=""
+IUSE="{iuse}"
 
 DEPEND=""
 RDEPEND=""
+
+src_compile() {{
+	cargo build --no-default-features \
+		--features {cargo_features}\
+		-j $(makeopts_jobs)\
+		$(usex debug "" --release) \
+		--verbose \
+	|| die "Cargo build failed"
+}}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ use cargo::{CliResult, Config};
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::PathBuf;
+use std::collections::HashMap;
 
 /// Finds the root Cargo.toml of the workspace
 fn workspace(config: &Config, manifest_path: Option<String>) -> CargoResult<Workspace> {
@@ -57,6 +58,46 @@ fn resolve<'a>(
     )?;
 
     Ok((packages, resolve))
+}
+
+fn all_features(package: &Package) -> &HashMap<String, Vec<String>> {
+    package.manifest()
+        .summary()
+        .features()
+}
+
+fn features_no_default(package: &Package) -> Vec<&String> {
+    all_features(package).keys()
+        .filter(|k| **k != "default".to_string())
+        .collect()
+}
+
+fn default_features(package: &Package) -> Vec<String> {
+    all_features(package)
+        .get("default")
+        .unwrap_or(&vec!["".to_string()])
+        .to_vec()
+}
+
+fn feature_to_iuse(package: &Package) -> String {
+    let mut s = "".to_string();
+    let defaults = default_features(package);
+    for feature in features_no_default(package) {
+        if defaults.contains(feature) {
+            s += "+";
+        }
+        s += feature;
+        s += " ";
+    }
+    s
+}
+
+fn feature_to_usex(package: &Package) -> String {
+    let mut s = "".to_string();
+    for feature in features_no_default(package) {
+        s += &format!("$(usex {} \"{},\" \"\")", feature, feature);
+    }
+    s
 }
 
 pub fn run(verbose: u32, quiet: bool) -> CliResult {
@@ -138,6 +179,8 @@ pub fn run(verbose: u32, quiet: bool) -> CliResult {
         crates = crates.join(""),
         cargo_ebuild_ver = env!("CARGO_PKG_VERSION"),
         this_year = 1900 + time::now().tm_year,
+        iuse = feature_to_iuse(package),
+        cargo_features = feature_to_usex(package),
     ).chain_err(|| "unable to write ebuild to disk")?;
 
     println!("Wrote: {}", ebuild_path.display());


### PR DESCRIPTION
Almost fix #12
The main drawback, crate fetching : you still fetch all crates, even those depending on a feature you don't want (said otherwise, the `CRATES` variable of the ebuild is always the same). That being said, I don't know if we can do anything better, since crate dependencies are hardcoded in the ebuild when using the cargo eclass.

All use flags matching features in the [default feature](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section) are activated by default (marked `+`)