### PR TITLE
Fixed local crates being added to ebuild

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,11 @@ pub fn gen_ebuild_data(manifest_path: Option<PathBuf>) -> Result<EbuildConfig> {
             root_pkg = Some(pkg.clone());
         }
 
-        crates.push(format!("{}-{}\n", pkg.name, pkg.version));
+        if let Some(src) = pkg.source {
+            if src.is_crates_io() {
+                crates.push(format!("{}-{}\n", pkg.name, pkg.version));
+            }
+        }
 
         if let Some(lic_list) = pkg.license.as_ref().map(|l| parse_license(&l)) {
             for lic in lic_list.iter() {


### PR DESCRIPTION
I've been trying to generate ebuilds for rust-analyzer but some local crates were erroneously being added to CRATES variable, so I modified cargo-ebuild to check whether the dependency comes from crates.io. I think this change also solves issues #18 and #34.