### PR TITLE
Implemented --filter-platform

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,9 @@ struct Args {
     #[structopt(name = "PATH", long = "manifest-path", parse(from_os_str))]
     /// Path to Cargo.toml.
     manifest_path: Option<PathBuf>,
+
+    #[structopt(long = "filter-platform")]
+    filter_platform: Option<String>,
 }
 
 #[structopt(
@@ -42,7 +45,7 @@ fn main() -> Result<()> {
     let Opt::Ebuild(opt) = Opt::from_args();
 
     // compute the data from the package that the build needs
-    let ebuild_data = gen_ebuild_data(opt.manifest_path)?;
+    let ebuild_data = gen_ebuild_data(opt.manifest_path, opt.filter_platform)?;
 
     let ebuild_path = format!("{}-{}.ebuild", ebuild_data.name, ebuild_data.version);
 


### PR DESCRIPTION
Just like in `cargo metadata`, this option will allow to choose a specific target triple like `x86_64-unknown-linux-gnu` or `i686-unknown-linux-gnu` and filter crate dependencies accordingly.