### PR TITLE
update output ebuild formatting

### DIFF
--- a/src/ebuild.template
+++ b/src/ebuild.template
@@ -15,13 +15,10 @@ DESCRIPTION="{description}"
 # does not provide this value so instead repository is used
 HOMEPAGE="{homepage}"
 SRC_URI="$(cargo_crate_uris ${{CRATES}})"
-RESTRICT="mirror"
+
 # License set may be more restrictive as OR is not respected
 # use cargo-license for a more accurate license picture
 LICENSE="{license}"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE=""
-
-DEPEND=""
-RDEPEND=""
+RESTRICT="mirror"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ pub fn gen_ebuild_data(manifest_path: Option<PathBuf>) -> Result<EbuildConfig> {
     for pkg in lockfile.packages {
         if let Some(src) = pkg.source {
             if src.is_default_registry() {
-                crates.push(format!("{}-{}\n", pkg.name, pkg.version));
+                crates.push(format!("\t{}-{}\n", pkg.name, pkg.version));
             }
         }
     }


### PR DESCRIPTION
- Indents crates with a tab
- Moves RESTRICT below KEYWORDS
- Removes empty IUSE/DEPENDs

```ebuild
# Copyright 2017-2020 Gentoo Authors
# Distributed under the terms of the GNU General Public License v2

# Auto-Generated by cargo-ebuild 0.3.2-alpha.0

EAPI=7

CRATES="
	ansi_term-0.11.0
	anyhow-1.0.31
	atty-0.2.14
	autocfg-1.0.0
	bitflags-1.2.1
	cargo-lock-4.0.1
	cargo_metadata-0.9.1
	clap-2.33.1
	either-1.5.3
	fixedbitset-0.2.0
	gumdrop-0.7.0
	gumdrop_derive-0.7.0
	hashbrown-0.8.1
	heck-0.3.1
	hermit-abi-0.1.14
	idna-0.2.0
	indexmap-1.5.0
	itertools-0.8.2
	itoa-0.4.6
	lazy_static-1.4.0
	libc-0.2.71
	matches-0.1.8
	percent-encoding-2.1.0
	petgraph-0.5.1
	proc-macro-error-1.0.2
	proc-macro-error-attr-1.0.2
	proc-macro2-1.0.18
	quote-1.0.7
	ryu-1.0.5
	semver-0.9.0
	semver-parser-0.7.0
	serde-1.0.112
	serde_derive-1.0.112
	serde_json-1.0.55
	strsim-0.8.0
	structopt-0.3.15
	structopt-derive-0.4.8
	syn-1.0.31
	syn-mid-0.5.0
	textwrap-0.11.0
	time-0.1.43
	tinyvec-0.3.3
	toml-0.5.6
	unicode-bidi-0.3.4
	unicode-normalization-0.1.13
	unicode-segmentation-1.6.0
	unicode-width-0.1.7
	unicode-xid-0.2.0
	url-2.1.1
	vec_map-0.8.2
	version_check-0.9.2
	winapi-0.3.8
	winapi-i686-pc-windows-gnu-0.4.0
	winapi-x86_64-pc-windows-gnu-0.4.0
"

inherit cargo

DESCRIPTION="Generates an ebuild for a package using the in-tree eclasses."
# Double check the homepage as the cargo_metadata crate
# does not provide this value so instead repository is used
HOMEPAGE="https://github.com/cardoe/cargo-ebuild"
SRC_URI="$(cargo_crate_uris ${CRATES})"

# License set may be more restrictive as OR is not respected
# use cargo-license for a more accurate license picture
LICENSE="Apache-2.0 BSL-1.0 MIT Zlib"
SLOT="0"
KEYWORDS="~amd64"
RESTRICT="mirror"
```